### PR TITLE
fix: `Mutation.registerVideo`を非推奨に

### DIFF
--- a/src/resolvers/Mutation/registerVideo/registerVideo.graphql
+++ b/src/resolvers/Mutation/registerVideo/registerVideo.graphql
@@ -1,5 +1,5 @@
 type Mutation {
-  registerVideo(input: RegisterVideoInput!): RegisterVideoPayload!
+  registerVideo(input: RegisterVideoInput!): RegisterVideoPayload! @deprecated
 }
 
 input RegisterVideoInput {


### PR DESCRIPTION
Fixes #438