### PR TITLE
revert: downgrade getmeili/meilisearch docker tag to v1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       NEO4J_AUTH: neo4j/password
 
   meilisearch:
-    image: getmeili/meilisearch:v1.1
+    image: getmeili/meilisearch:v1.0
     ports:
       - target: 7700
         published: 7700


### PR DESCRIPTION
This reverts commit 338df2861154a28a3ad2c194e25e1270725259ea.