### PR TITLE
fix: `implicitizeTagParent`のリソルバとしての登録忘れを修正

### DIFF
--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -11,6 +11,7 @@ import { resolverChangeUserDisplayName } from "./changeUserDisplayName/resolver.
 import { createMylist } from "./createMylist/createMylist.js";
 import { createMylistGroup } from "./createMylistGroup/createMylistGroup.js";
 import { resolverExplicitizeTagParent } from "./explicitizeTagParent/resolver.js";
+import { resolverImplicitizeTagParent } from "./implicitizeTagParent/resolver.js";
 import { resolverLikeVideo } from "./likeVideo/resolver.js";
 import { registerCategoryTag } from "./registerCategoryTag/resolver.js";
 import { resolverRegisterCategoryTagTyping } from "./registerCategoryTagTyping/resolver.js";
@@ -37,6 +38,7 @@ export const resolveMutation = (deps: ResolverDeps) =>
     createMylist: createMylist(deps),
     createMylistGroup: createMylistGroup(deps),
     explicitizeTagParent: resolverExplicitizeTagParent(deps),
+    implicitizeTagParent: resolverImplicitizeTagParent(deps),
     likeVideo: resolverLikeVideo(deps),
     registerCategoryTag: registerCategoryTag(deps),
     registerCategoryTagTyping: resolverRegisterCategoryTagTyping(deps),


### PR DESCRIPTION
Fixes #549