### PR TITLE
`Query.whoami`は非推奨にする

### DIFF
--- a/src/resolvers/Query/whoami/whoami.graphql
+++ b/src/resolvers/Query/whoami/whoami.graphql
@@ -1,3 +1,3 @@
 type Query {
-  whoami: User! @auth
+  whoami: User! @auth @deprecated(reason: "Use `Query.viewer` instead")
 }


### PR DESCRIPTION
Fixes #975